### PR TITLE
Remove deprecated DSSKey and bump paramiko to 4.0.0

### DIFF
--- a/arl/AuthenticatedResourceLocator.py
+++ b/arl/AuthenticatedResourceLocator.py
@@ -11,7 +11,7 @@ import tarfile
 import zipfile
 import google.cloud.storage
 from google.oauth2 import service_account
-from paramiko import RSAKey, DSSKey, ECDSAKey, Ed25519Key
+from paramiko import RSAKey, ECDSAKey, Ed25519Key
 import dulwich
 from dulwich import porcelain
 from dulwich.contrib.paramiko_vendor import ParamikoSSHVendor
@@ -226,7 +226,7 @@ class AuthenticatedResourceLocator( object ):
                 private_key = self._authData
 
                 pkey = None
-                for pkey_class in (RSAKey, DSSKey, ECDSAKey, Ed25519Key):
+                for pkey_class in (RSAKey, ECDSAKey, Ed25519Key):
                     try:
                         pkey = pkey_class.from_private_key(private_key)
                         break

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ greenlet==3.0.3
 idna==3.7
 iniconfig==2.0.0
 packaging==24.1
-paramiko==3.4.1
+paramiko==4.0.0
 pluggy==1.5.0
 proto-plus==1.24.0
 protobuf==5.29.6


### PR DESCRIPTION
## Summary
- Remove `DSSKey` import and usage from `AuthenticatedResourceLocator.py` — paramiko v4 dropped DSA/DSS key support entirely
- Bump `paramiko` from 3.4.1 to 4.0.0 in `requirements.txt`
- DSA keys are deprecated and insecure (limited to 1024 bits), so no functional impact expected

## Test plan
- [x] Verified paramiko 4.0.0 import succeeds without DSSKey
- [x] Verified full module loads cleanly (`from arl.AuthenticatedResourceLocator import AuthenticatedResourceLocator`)
- [x] Ran test suite: 7/10 pass; 3 failures are pre-existing 404s against a removed upstream repo (unrelated)
- [x] Confirmed master is currently broken (DSSKey ImportError prevents any tests from running)