### PR TITLE
Fix cffi/cryptography pin conflict and repoint dead github tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bcrypt==4.2.0
 cachetools==5.4.0
 certifi==2024.7.4
-cffi==1.17.0
+cffi==2.0.0
 charset-normalizer==3.3.2
 cryptography==46.0.7
 dulwich==0.22.1

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -93,7 +93,7 @@ def test_githubRootNoAuth():
     assert( 0 != nElemFound )
 
 def test_githubSubdirNoAuth():
-    testArl = "[github,refractionPOINT/sigma/rules/windows/builtin]"
+    testArl = "[github,refractionPOINT/sigma-limacharlie/scripts]"
     nElemFound = 0
     with ARL( testArl ) as r:
         for fileName, fileContent in r:
@@ -103,7 +103,7 @@ def test_githubSubdirNoAuth():
     assert( 0 != nElemFound )
 
 def test_githubSigleFileNoAuth():
-    testArl = "[github,refractionPOINT/sigma/README.md]"
+    testArl = "[github,refractionPOINT/sigma-limacharlie/README.md]"
     nElemFound = 0
     with ARL( testArl ) as r:
         for fileName, fileContent in r:
@@ -125,7 +125,7 @@ def test_githubSigleFileNoAuth():
 #     assert( 0 != nElemFound )
 
 def test_githubBranch():
-    testArl = "[github,refractionPOINT/sigma/lc-rules/windows_sysmon/?ref=lc-rules]"
+    testArl = "[github,refractionPOINT/sigma-limacharlie/latest/windows_sysmon/?ref=rules]"
     nElemFound = 0
     with ARL( testArl ) as r:
         for fileName, fileContent in r:


### PR DESCRIPTION
## Summary

Two small fixes to `authenticated_resource_locator`:

### 1. Dependency conflict (`cffi` vs `cryptography`)
`requirements.txt` pinned `cffi==1.17.0`, but `cryptography==46.0.7` requires `cffi>=2.0.0`. A clean `pip install -r requirements.txt` failed with a `ResolutionImpossible` error. Bumped the pin to `cffi==2.0.0` (the version pip resolves to).

### 2. Test cleanup (dead `github`-protocol fixtures)
Three tests pointed at `refractionPOINT/sigma`, which has been deleted (every request 404'd). Repointed them at the live successor repo `sigma-limacharlie`, preserving exactly what each test exercises:

| Test | Coverage | New fixture |
|------|----------|-------------|
| `test_githubSubdirNoAuth` | recursive subdir listing | `sigma-limacharlie/scripts` (master) |
| `test_githubSigleFileNoAuth` | single-file fetch | `sigma-limacharlie/README.md` (master) |
| `test_githubBranch` | non-default branch `?ref=` | `sigma-limacharlie/latest/windows_sysmon/?ref=rules` |

No tests were skipped or weakened.

## Test plan
Clean venv, `pip install -r requirements.txt` (now resolves), then `pytest tests/`:

```
10 passed in 76.96s
```

Was 7/10 before (the 3 github tests failed against the deleted repo).