### PR TITLE
Vendor ParamikoSSHVendor to support dulwich 1.2.5

### DIFF
--- a/arl/AuthenticatedResourceLocator.py
+++ b/arl/AuthenticatedResourceLocator.py
@@ -14,7 +14,7 @@ from google.oauth2 import service_account
 from paramiko import RSAKey, ECDSAKey, Ed25519Key
 import dulwich
 from dulwich import porcelain
-from dulwich.contrib.paramiko_vendor import ParamikoSSHVendor
+from .paramiko_vendor import ParamikoSSHVendor
 
 class AuthenticatedResourceLocator( object ):
     _supportedMethods = {

--- a/arl/paramiko_vendor.py
+++ b/arl/paramiko_vendor.py
@@ -1,0 +1,113 @@
+# paramiko_vendor.py -- paramiko implementation of the dulwich SSHVendor interface
+#
+# Vendored from dulwich.contrib.paramiko_vendor (Copyright (C) 2013 Aaron
+# O'Mullan <aaron.omullan@friendco.de>), which was dual-licensed under the
+# Apache License, Version 2.0 and the GNU General Public License v2.0 or later.
+#
+# dulwich dropped the contrib/ package from its distribution as of 0.25.0, so
+# this adapter is maintained here. It lets dulwich authenticate over SSH using
+# an in-memory paramiko private key (paramiko is already a dependency of this
+# project), which the SSH vendors dulwich still ships (subprocess ssh, plink)
+# cannot do.
+
+"""Paramiko-backed SSH vendor for dulwich.
+
+Install it by overriding ``dulwich.client.get_ssh_vendor``::
+
+    from dulwich import client as _mod_client
+    from arl.paramiko_vendor import ParamikoSSHVendor
+    _mod_client.get_ssh_vendor = lambda: ParamikoSSHVendor(pkey=pkey)
+"""
+
+import paramiko
+import paramiko.client
+
+
+class _ParamikoWrapper:
+    def __init__(self, client, channel) -> None:
+        self.client = client
+        self.channel = channel
+
+        # Channel must block
+        self.channel.setblocking(True)
+
+    @property
+    def stderr(self):
+        return self.channel.makefile_stderr("rb")
+
+    def can_read(self):
+        return self.channel.recv_ready()
+
+    def write(self, data):
+        return self.channel.sendall(data)
+
+    def read(self, n=None):
+        data = self.channel.recv(n)
+        data_len = len(data)
+
+        # Closed socket
+        if not data:
+            return b""
+
+        # Read more if needed
+        if n and data_len < n:
+            diff_len = n - data_len
+            return data + self.read(diff_len)
+        return data
+
+    def close(self) -> None:
+        self.channel.close()
+
+
+class ParamikoSSHVendor:
+    # http://docs.paramiko.org/en/2.4/api/client.html
+
+    def __init__(self, **kwargs) -> None:
+        self.kwargs = kwargs
+
+    def run_command(
+        self,
+        host,
+        command,
+        username=None,
+        port=None,
+        password=None,
+        pkey=None,
+        key_filename=None,
+        ssh_command=None,
+        protocol_version=None,
+        **kwargs,
+    ):
+        # ssh_command is part of dulwich's SSHVendor.run_command interface but
+        # is meaningless for a paramiko connection; accept and ignore it so it
+        # is never forwarded into paramiko's connect().
+        client = paramiko.SSHClient()
+
+        connection_kwargs = {"hostname": host}
+        connection_kwargs.update(self.kwargs)
+        if username:
+            connection_kwargs["username"] = username
+        if port:
+            connection_kwargs["port"] = port
+        if password:
+            connection_kwargs["password"] = password
+        if pkey:
+            connection_kwargs["pkey"] = pkey
+        if key_filename:
+            connection_kwargs["key_filename"] = key_filename
+        connection_kwargs.update(kwargs)
+
+        policy = paramiko.client.MissingHostKeyPolicy()
+        client.set_missing_host_key_policy(policy)
+        client.connect(**connection_kwargs)
+
+        # Open SSH session
+        channel = client.get_transport().open_session()
+
+        if protocol_version is None or protocol_version == 2:
+            channel.set_environment_variable(name="GIT_PROTOCOL", value="version=2")
+
+        # Run commands
+        channel.exec_command(command)
+
+        return _ParamikoWrapper(client, channel)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2024.7.4
 cffi==2.0.0
 charset-normalizer==3.3.2
 cryptography==46.0.7
-dulwich==0.22.1
+dulwich==1.2.5
 gevent==24.2.1
 google-api-core==2.19.1
 google-auth==2.33.0


### PR DESCRIPTION
## Summary

The Dependabot bump of `dulwich` 0.22.1 → 1.2.5 (#20) cannot merge as-is: it breaks the package.

`arl/AuthenticatedResourceLocator.py` imports `ParamikoSSHVendor` from `dulwich.contrib.paramiko_vendor` at module load time. dulwich **dropped the `contrib/` package from its distribution in 0.25.0** (changelog: *"No longer ship `contrib/` as part of the distribution… now excluded from the installed package"*), so that module no longer exists in 1.2.5. The result is a `ModuleNotFoundError: No module named 'dulwich.contrib'` on import, which takes down **every** code path (HTTPS/tarball/zip included), not just the SSH clone path. Test collection fails outright.

## Fix

- Vendor an equivalent paramiko-backed `SSHVendor` into `arl/paramiko_vendor.py` (faithful copy of dulwich's old contrib implementation; paramiko is already a pinned dependency). This is the only SSH vendor capable of authenticating with an **in-memory** private key, which is how ARL clones private repos.
- Import `ParamikoSSHVendor` from the local module instead of the removed dulwich contrib path.
- Bump `dulwich` 0.22.1 → 1.2.5 in `requirements.txt`.
- The vendored `run_command` explicitly accepts and ignores dulwich's newer `ssh_command` argument so it is never forwarded into paramiko's `connect()`.

## Verification (local, dulwich 1.2.5 + paramiko 5.0.0)

- `import arl` succeeds (previously raised `ModuleNotFoundError`).
- Vendor wiring confirmed: `dulwich.client.get_ssh_vendor` override works and `run_command` accepts every argument dulwich 1.2.5 passes (`host, command, username, port, password, key_filename, ssh_command, protocol_version`).
- Full test suite: **10 passed** (was 0 — collection error — before the fix).

Note: the SSH-auth clone path has no automated test (the SSH test in `tests/` is commented out and needs live credentials); its import/interface compatibility is verified statically above.

Supersedes #20.