### PR TITLE
Bump cryptography to 50.0.0 (CVE-2026-69247)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cachetools==5.4.0
 certifi==2024.7.4
 cffi==2.0.0
 charset-normalizer==3.3.2
-cryptography==48.0.1
+cryptography==50.0.0
 dulwich==1.2.5
 gevent==24.2.1
 google-api-core==2.19.1


### PR DESCRIPTION
## Summary

| CVE | Severity | Package | Old | New |
|---|---|---|---|---|
| CVE-2026-69247 | HIGH | cryptography | 48.0.1 | 50.0.0 |

Affected range is `>= 44.0.0, < 50.0.0`; 50.0.0 is the first patched release. Same bump already landed in `python-limacharlie` and `support-bot` today.

## Test plan

- [x] `pip install -r requirements.txt` in a clean venv — resolves cleanly, `cryptography 50.0.0` confirmed installed
- [x] `import arl` — OK
- [x] `pytest tests/` — **10/10 passed**

## Notes

Single-line change to `requirements.txt`.